### PR TITLE
Issue6 #6 初期状態からDatabaseとTableが作成されるように修正しました

### DIFF
--- a/dump.sql
+++ b/dump.sql
@@ -5,6 +5,30 @@
 -- Table structure for table `shop_product`
 --
 
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Current Database: `Shop`
+--
+
+CREATE DATABASE /*!32312 IF NOT EXISTS*/ `Shop` /*!40100 DEFAULT CHARACTER SET utf8 */;
+
+USE `Shop`;
+
+
+--
+-- Dumping data for table `shop_product`
+--
+
 DROP TABLE IF EXISTS `shop_product`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -13,9 +37,13 @@ CREATE TABLE `shop_product` (
   `name` varchar(45) DEFAULT NULL,
   `price` int(11) DEFAULT NULL,
   `gazou` varchar(45) DEFAULT NULL,
-  PRIMARY KEY (`code`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
+  PRIMARY KEY (`code`),
+  UNIQUE KEY `code_2` (`code`),
+  KEY `code` (`code`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
 -- Table structure for table `shop_staff`
 --
 
@@ -24,9 +52,20 @@ DROP TABLE IF EXISTS `shop_staff`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `shop_staff` (
   `code` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(45) DEFAULT NULL,
+  `name` varchar(45) NOT NULL,
   `password` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`code`),
-  UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+  UNIQUE KEY `name` (`name`),
+  UNIQUE KEY `name_2` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
 -- Dump completed on 2017-02-06 

--- a/dump.sql
+++ b/dump.sql
@@ -2,31 +2,44 @@
 --
 -- Host: 0.0.0.0    Database: Shop
 -- ------------------------------------------------------
--- Table structure for table `shop_product`
+
 --
+-- Drop all tables and database
+--
+USE `Shop`;
 
 DROP TABLE IF EXISTS `shop_product`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+DROP TABLE IF EXISTS `shop_staff`;
+DROP DATABASE `Shop`;
+
+--
+-- Create Database and Set Privileges
+-- 
+CREATE DATABASE /*!32312 IF NOT EXISTS*/ `Shop` /*!40100 DEFAULT CHARACTER SET utf8 */;
+GRANT ALL PRIVILEGES ON `Shop`.* to shopadmin@localhost IDENTIFIED BY 'AdminPassword';
+
+-- 
+USE `Shop`;
+
+--
+-- Create Table `shop_product`
+--
 CREATE TABLE `shop_product` (
   `code` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(45) DEFAULT NULL,
+  `name` varchar(45) NOT NULL,
   `price` int(11) DEFAULT NULL,
   `gazou` varchar(45) DEFAULT NULL,
-  PRIMARY KEY (`code`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
-
--- Table structure for table `shop_staff`
---
-
-DROP TABLE IF EXISTS `shop_staff`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `shop_staff` (
-  `code` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(45) DEFAULT NULL,
-  `password` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`code`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
--- Dump completed on 2017-02-06 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Createa Table `shop_staff`
+--
+CREATE TABLE `shop_staff` (
+  `code` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(45) NOT NULL,
+  `password` varchar(45) NOT NULL,
+  PRIMARY KEY (`code`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/dump.sql
+++ b/dump.sql
@@ -1,20 +1,13 @@
 -- MySQL dump 10.13  Distrib 5.5.44, for debian-linux-gnu (x86_64)
---
--- Host: 0.0.0.0    Database: Shop
--- ------------------------------------------------------
--- Table structure for table `shop_product`
---
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+--
+-- Drop all tables and database
+--
+USE `Shop`;
+
+DROP TABLE IF EXISTS `shop_product`;
+DROP TABLE IF EXISTS `shop_staff`;
+DROP DATABASE `Shop`;
 
 --
 -- Current Database: `Shop`
@@ -22,50 +15,32 @@
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `Shop` /*!40100 DEFAULT CHARACTER SET utf8 */;
 
-USE `Shop`;
+GRANT ALL PRIVILEGES ON `Shop`.* to shopadmin@localhost IDENTIFIED BY 'AdminPassword';
 
+USE `Shop`;
 
 --
 -- Dumping data for table `shop_product`
 --
 
-DROP TABLE IF EXISTS `shop_product`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `shop_product` (
   `code` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(45) DEFAULT NULL,
   `price` int(11) DEFAULT NULL,
   `gazou` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`code`),
-  UNIQUE KEY `code_2` (`code`),
   KEY `code` (`code`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
 -- Table structure for table `shop_staff`
 --
 
-DROP TABLE IF EXISTS `shop_staff`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `shop_staff` (
   `code` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(45) NOT NULL,
   `password` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`code`),
-  UNIQUE KEY `name` (`name`),
-  UNIQUE KEY `name_2` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on 2017-02-06 


### PR DESCRIPTION
Cloud9上でMySQL実行後に、Database(Shop)とTableを作成するsqlスクリプトです。
初期状態（githubからcloneした直後）と既にDatabaseとテーブルが存在する場合の両方に対応して、新規に作成し直すように修正してあります。

restoreは
$ mysql -u clud9account < dump.sql
で実行して下さい

このファイルでは、shopadminはローカル接続のみ許可されているので、リモート接続が必要な場合にはGRANTを追加する必要があります
